### PR TITLE
fix: update capitalize regex to allow numbers

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -160,7 +160,7 @@ export async function compileRule(
   if (!Array.isArray(schemas))
     schemas = [schemas]
 
-  const capitalizedName = name.replace(/(?:^|[^\w]+)([a-z])/g, (_, c) => c.toUpperCase())
+  const capitalizedName = name.replace(/(?:^|[^\w]+)([a-z|\d])/g, (_, c) => c.toUpperCase())
 
   const jsdoc: string[] = []
   if (meta.docs?.description)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes an issue where when the rule name is made capitalized and it includes a number after a `-` it would output invalid typescript.

<img width="1112" alt="image" src="https://github.com/antfu/eslint-typegen/assets/40726067/82afb1db-7064-4847-8f75-54977df48501">

After this fix, this is the code that gets outputted.
<img width="1049" alt="image" src="https://github.com/antfu/eslint-typegen/assets/40726067/d82e76f0-57ab-413c-9379-6b11f94003fd">



### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
