### PR TITLE
fix: avoid an error when rule is not an object (#8)

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -109,7 +109,7 @@ export async function pluginsToRulesDTS(
 
   for (const [pluginName, plugin] of Object.entries(plugins)) {
     for (const [ruleName, rule] of Object.entries(plugin.rules || {})) {
-      if ('meta' in rule) {
+      if (rule?.meta) {
         rules.push([
           pluginName
             ? `${pluginName}/${ruleName}`


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Linked Issues

fix https://github.com/antfu/eslint-typegen/issues/8

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
