### PR TITLE
fix: fix `Fallback to unknown` generating invalid type name

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -235,7 +235,7 @@ export async function compileRule(
   catch (error) {
     console.warn(`Failed to compile schema ${ruleName} for rule ${ruleName}. Falling back to unknown.`)
     console.error(error)
-    lines.push(`export type ${ruleName} = unknown\n`)
+    lines.push(`export type ${id} = unknown\n`)
   }
 
   lines = lines

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,7 @@
 import { vue } from '@antfu/eslint-config'
 import { expect, it } from 'vitest'
 import { flatConfigsToRulesDTS, pluginsToRulesDTS } from '../src/core'
+import { invalidJsonSchemaPlugin } from './input/invalid-json-schema-plugin'
 
 it('pluginsToRuleOptions', async () => {
   await expect(await pluginsToRulesDTS({
@@ -25,6 +26,13 @@ it('core rules', async () => {
     '': { rules: Object.fromEntries(builtinRules.entries()) },
   }))
     .toMatchFileSnapshot('./output/core-rules.d.ts')
+})
+
+it('invalid JSON schema plugin', async () => {
+  await expect(await pluginsToRulesDTS({
+    'invalid-json-schema-plugin': invalidJsonSchemaPlugin,
+  }))
+    .toMatchFileSnapshot('./output/invalid-json-schema-plugin.d.ts')
 })
 
 it('flatConfigsToRuleOptions', async () => {

--- a/test/input/invalid-json-schema-plugin.ts
+++ b/test/input/invalid-json-schema-plugin.ts
@@ -1,0 +1,22 @@
+import type { ESLint, Rule } from 'eslint'
+
+export const invalidJsonSchemaPlugin: ESLint.Plugin = {
+  rules: {
+    'invalid-json-schema-rule': {
+      create: () => null as unknown as Rule.RuleListener,
+      meta: {
+        docs: {
+          description: 'This rules points to a non-existing schema',
+        },
+        schema: {
+          allOf: [
+            {
+              $ref: '#/definitions/some-definition-that-does-not-exist',
+            },
+          ],
+          type: 'object',
+        },
+      },
+    },
+  },
+}

--- a/test/output/invalid-json-schema-plugin.d.ts
+++ b/test/output/invalid-json-schema-plugin.d.ts
@@ -1,0 +1,20 @@
+/* eslint-disable */
+/* prettier-ignore */
+import type { Linter } from 'eslint'
+
+declare module 'eslint' {
+  namespace Linter {
+    interface RulesRecord extends RuleOptions {}
+  }
+}
+
+export interface RuleOptions {
+  /**
+   * This rules points to a non-existing schema
+   */
+  'invalid-json-schema-plugin/invalid-json-schema-rule'?: Linter.RuleEntry<InvalidJsonSchemaPluginInvalidJsonSchemaRule>
+}
+
+/* ======= Declarations ======= */
+// ----- invalid-json-schema-plugin/invalid-json-schema-rule -----
+type InvalidJsonSchemaPluginInvalidJsonSchemaRule = unknown


### PR DESCRIPTION
Fixes #10.

### Description

The generated exported type for a rule that failed to have its JSON schema compiled is invalid (see the example in the issue):

```ts
  /**
   * Enforce sorted imports.
   * @see https://perfectionist.dev/rules/sort-imports
   */
  'perfectionist/sort-imports'?: Linter.RuleEntry<PerfectionistSortImports>

[...]

// ----- perfectionist/sort-imports -----
type perfectionist/sort-imports = unknown // Instead of PerfectionistSortImports
```

This PR simply generates the correct name.

### Before/after

#### Before

<details>

<summary>Details</summary>

```ts
/* eslint-disable */
/* prettier-ignore */
import type { Linter } from 'eslint'

declare module 'eslint' {
  namespace Linter {
    interface RulesRecord extends RuleOptions {}
  }
}

export interface RuleOptions {
  /**
   * This rules points to a non-existing schema
   */
  'invalid-json-schema-plugin/invalid-json-schema-rule'?: Linter.RuleEntry<InvalidJsonSchemaPluginInvalidJsonSchemaRule>
}

/* ======= Declarations ======= */
// ----- invalid-json-schema-plugin/invalid-json-schema-rule -----
type invalid-json-schema-plugin/invalid-json-schema-rule = unknown
```

</details>

#### After

<details>

<summary>Details</summary>

```ts
/* eslint-disable */
/* prettier-ignore */
import type { Linter } from 'eslint'

declare module 'eslint' {
  namespace Linter {
    interface RulesRecord extends RuleOptions {}
  }
}

export interface RuleOptions {
  /**
   * This rules points to a non-existing schema
   */
  'invalid-json-schema-plugin/invalid-json-schema-rule'?: Linter.RuleEntry<InvalidJsonSchemaPluginInvalidJsonSchemaRule>
}

/* ======= Declarations ======= */
// ----- invalid-json-schema-plugin/invalid-json-schema-rule -----
type InvalidJsonSchemaPluginInvalidJsonSchemaRule = unknown
```

</details>


### Commit split:

- First commit adds failing tests.
- Second commit fixes the issue.

### Linked Issues

- #10.

