### PR TITLE
fix: fix JSON schema with root ID not parsed correctly

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -212,11 +212,17 @@ export async function compileRule(
     ? { type: 'array', items: meta.schema, definitions: meta.schema?.[0]?.definitions }
     : meta.schema
 
+  let overriddenRootSchemaId: string | undefined
+  let isRootSchema = true
+
   try {
     const compiled = await compileSchema(schema, id, {
       unreachableDefinitions: false,
       strictIndexSignatures: true,
       customName(schema, keyName) {
+        const canOverrideRootSchemaId = isRootSchema
+        isRootSchema = false
+
         const resolved = schema.title || schema.$id || keyName
         if (resolved === id)
           return id
@@ -224,6 +230,8 @@ export async function compileRule(
           return undefined!
 
         const normalizedName = `_${normalizeIdentifier(`${id}_${resolved}`)}`
+        if (canOverrideRootSchemaId)
+          overriddenRootSchemaId = normalizedName
 
         return normalizedName
       },
@@ -251,7 +259,7 @@ export async function compileRule(
   return {
     name: ruleName,
     jsdoc,
-    typeName: id,
+    typeName: overriddenRootSchemaId ?? id,
     typeDeclarations: lines,
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -218,12 +218,14 @@ export async function compileRule(
       strictIndexSignatures: true,
       customName(schema, keyName) {
         const resolved = schema.title || schema.$id || keyName
-        if (resolved === id) {
+        if (resolved === id)
           return id
-        }
         if (!resolved)
           return undefined!
-        return `_${normalizeIdentifier(`${id}_${resolved}`)}`
+
+        const normalizedName = `_${normalizeIdentifier(`${id}_${resolved}`)}`
+
+        return normalizedName
       },
       ...compileOptions,
     })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,6 +2,7 @@ import { vue } from '@antfu/eslint-config'
 import { expect, it } from 'vitest'
 import { flatConfigsToRulesDTS, pluginsToRulesDTS } from '../src/core'
 import { invalidJsonSchemaPlugin } from './input/invalid-json-schema-plugin'
+import { pluginWithSchemaIds } from './input/plugin-with-schema-ids'
 
 it('pluginsToRuleOptions', async () => {
   await expect(await pluginsToRulesDTS({
@@ -33,6 +34,13 @@ it('invalid JSON schema plugin', async () => {
     'invalid-json-schema-plugin': invalidJsonSchemaPlugin,
   }))
     .toMatchFileSnapshot('./output/invalid-json-schema-plugin.d.ts')
+})
+
+it('json schema with ids', async () => {
+  await expect(await pluginsToRulesDTS({
+    plugin: pluginWithSchemaIds,
+  }))
+    .toMatchFileSnapshot('./output/plugin-with-schema-ids.d.ts')
 })
 
 it('flatConfigsToRuleOptions', async () => {

--- a/test/input/plugin-with-schema-ids.ts
+++ b/test/input/plugin-with-schema-ids.ts
@@ -1,0 +1,51 @@
+import type { ESLint, Rule } from 'eslint'
+
+export const pluginWithSchemaIds: ESLint.Plugin = {
+  rules: {
+    'schema-with-id-at-root': {
+      create: () => null as unknown as Rule.RuleListener,
+      meta: {
+        schema: {
+          id: 'schemaId',
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            a: {
+              id: 'aId',
+              type: 'string',
+            },
+            b: {
+              id: 'bId',
+              additionalProperties: false,
+              type: 'object',
+              properties: {
+                b1: {
+                  type: 'string',
+                },
+              },
+            },
+            c: {
+              additionalProperties: false,
+              type: 'object',
+              properties: {
+                c1: {
+                  type: 'string',
+                  id: 'c1Id',
+                },
+              },
+            },
+            d: {
+              additionalProperties: false,
+              type: 'object',
+              properties: {
+                da: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}

--- a/test/output/plugin-with-schema-ids.d.ts
+++ b/test/output/plugin-with-schema-ids.d.ts
@@ -1,0 +1,31 @@
+/* eslint-disable */
+/* prettier-ignore */
+import type { Linter } from 'eslint'
+
+declare module 'eslint' {
+  namespace Linter {
+    interface RulesRecord extends RuleOptions {}
+  }
+}
+
+export interface RuleOptions {
+  'plugin/schema-with-id-at-root'?: Linter.RuleEntry<_PluginSchemaWithIdAtRootSchemaId>
+}
+
+/* ======= Declarations ======= */
+// ----- plugin/schema-with-id-at-root -----
+type _PluginSchemaWithIdAtRootAId = string
+type _PluginSchemaWithIdAtRootC1Id = string
+interface _PluginSchemaWithIdAtRootSchemaId {
+  a?: _PluginSchemaWithIdAtRootAId
+  b?: _PluginSchemaWithIdAtRootBId
+  c?: {
+    c1?: _PluginSchemaWithIdAtRootC1Id
+  }
+  d?: {
+    da?: string
+  }
+}
+interface _PluginSchemaWithIdAtRootBId {
+  b1?: string
+}


### PR DESCRIPTION
### Description

A JSON schema with an ID at the root will generate typings that do not compile (see the reproduction case in the issue).

### Linked Issues

Fixes #12 

### Before/After

JSON schema
```ts
{
  id: "schemaId"
}
```

Before
```ts
/* eslint-disable */
/* prettier-ignore */
import type { Linter } from 'eslint'

declare module 'eslint' {
  namespace Linter {
    interface RulesRecord extends RuleOptions {}
  }
}

export interface RuleOptions {
  'plugin/schema-with-id-at-root'?: Linter.RuleEntry<PluginSchemaWithIdAtRoot>
}

/* ======= Declarations ======= */
// ----- plugin/schema-with-id-at-root -----
interface _PluginSchemaWithIdAtRootSchemaId {
  [k: string]: unknown | undefined
}
```

After
```ts
/* eslint-disable */
/* prettier-ignore */
import type { Linter } from 'eslint'

declare module 'eslint' {
  namespace Linter {
    interface RulesRecord extends RuleOptions {}
  }
}

export interface RuleOptions {
  'plugin/schema-with-id-at-root'?: Linter.RuleEntry<_PluginSchemaWithIdAtRootSchemaId>
}

/* ======= Declarations ======= */
// ----- plugin/schema-with-id-at-root -----
interface _PluginSchemaWithIdAtRootSchemaId {
  [k: string]: unknown | undefined
}
```